### PR TITLE
explicit encoding for fopen in R2021a

### DIFF
--- a/onc/+util/save_as_file.m
+++ b/onc/+util/save_as_file.m
@@ -7,39 +7,44 @@
 % @param overwrite If true will overwrite files with the same name
 % @return (numeric) Result code from {0: done, -1: error, -2: fileExists}
 function endCode = save_as_file(response, filePath, fileName, varargin)
-    [overwrite] = util.param(varargin, 'overwrite', false);
-    
-    fullPath = fileName;
-    if ~isempty(filePath)
-        fullPath = sprintf('%s/%s', filePath, fileName);
-        % Create outPath directory if not exists
-        if not(util.prepare_directory(filePath))
-            fprintf('   ERROR: Could not create ouput path at "%s". File "%s" was NOT saved.\n', filePath, fileName);
-            endCode = -1;
-            return;
-        end
-    end
+[overwrite] = util.param(varargin, 'overwrite', false);
 
-    % Save file in outPath if it doesn't exist yet
-    if overwrite || not(isfile(fullPath))
-        try
-            f = fopen(fullPath, 'w');
-            if f ~= -1
-                fwrite(f, response.Body.Data);
-            else
-                endCode = -1;
-                return;
-            end
-            fclose(f);
-        catch ex
-            disp(ex);
-            endCode = -1;
-            return;
-        end
-    else
-        endCode = -2;
+fullPath = fileName;
+if ~isempty(filePath)
+    fullPath = sprintf('%s/%s', filePath, fileName);
+    % Create outPath directory if not exists
+    if not(util.prepare_directory(filePath))
+        fprintf('   ERROR: Could not create ouput path at "%s". File "%s" was NOT saved.\n', filePath, fileName);
+        endCode = -1;
         return;
     end
-    
-    endCode = 0;
+end
+
+% Save file in outPath if it doesn't exist yet
+if overwrite || not(isfile(fullPath))
+    try
+        if strcmp('2021a',version('-release'))
+            f = fopen(fullPath, 'w','ISO-8859-1');
+        else
+            f = fopen(fullPath, 'w');
+        end
+        
+        if f ~= -1
+            fwrite(f, response.Body.Data);
+        else
+            endCode = -1;
+            return;
+        end
+        fclose(f);
+    catch ex
+        disp(ex);
+        endCode = -1;
+        return;
+    end
+else
+    endCode = -2;
+    return;
+end
+
+endCode = 0;
 end


### PR DESCRIPTION
Matlab  R2021a version defaults to 'UTF-8' encoding, causing problems while downloading binary files. The proposed change identifies the Matlab version being used and explicitly adds the encoding ('ISO-8859-1')  to fopen if the Matlab version is R2021a.  After this change unit test results are identical to those before the change.